### PR TITLE
feat: add plan restriction toggle

### DIFF
--- a/packages/frontend/editor-ui/src/Interface.ts
+++ b/packages/frontend/editor-ui/src/Interface.ts
@@ -1084,6 +1084,7 @@ export type UsageState = {
 		};
 		managementToken?: string;
 	};
+	plansEnabled: boolean;
 };
 
 export type NodeAuthenticationOption = {

--- a/packages/frontend/editor-ui/src/stores/usage.store.ts
+++ b/packages/frontend/editor-ui/src/stores/usage.store.ts
@@ -16,6 +16,7 @@ export type UsageTelemetry = {
 const DEFAULT_PLAN_NAME = 'Community';
 const DEFAULT_STATE: UsageState = {
 	loading: true,
+	plansEnabled: true,
 	data: {
 		usage: {
 			activeWorkflowTriggers: {
@@ -41,18 +42,23 @@ export const useUsageStore = defineStore('usage', () => {
 
 	const state = reactive<UsageState>({ ...DEFAULT_STATE });
 
+	const plansEnabled = computed(() => state.plansEnabled);
 	const planName = computed(() => state.data.license.planName || DEFAULT_PLAN_NAME);
 	const planId = computed(() => state.data.license.planId);
-	const activeWorkflowTriggersLimit = computed(() => state.data.usage.activeWorkflowTriggers.limit);
+	const activeWorkflowTriggersLimit = computed(() =>
+		state.plansEnabled ? state.data.usage.activeWorkflowTriggers.limit : -1,
+	);
 	const activeWorkflowTriggersCount = computed(() => state.data.usage.activeWorkflowTriggers.value);
-	const workflowsWithEvaluationsLimit = computed(
-		() => state.data.usage.workflowsHavingEvaluations.limit,
+	const workflowsWithEvaluationsLimit = computed(() =>
+		state.plansEnabled ? state.data.usage.workflowsHavingEvaluations.limit : -1,
 	);
 	const workflowsWithEvaluationsCount = computed(
 		() => state.data.usage.workflowsHavingEvaluations.value,
 	);
-	const executionPercentage = computed(
-		() => (activeWorkflowTriggersCount.value / activeWorkflowTriggersLimit.value) * 100,
+	const executionPercentage = computed(() =>
+		activeWorkflowTriggersLimit.value > 0
+			? (activeWorkflowTriggersCount.value / activeWorkflowTriggersLimit.value) * 100
+			: 0,
 	);
 	const instanceId = computed(() => settingsStore.settings.instanceId);
 	const managementToken = computed(() => state.data.managementToken);
@@ -72,6 +78,10 @@ export const useUsageStore = defineStore('usage', () => {
 
 	const setData = (data: UsageState['data']) => {
 		state.data = data;
+	};
+
+	const setPlansEnabled = (value: boolean) => {
+		state.plansEnabled = value;
 	};
 
 	const getLicenseInfo = async () => {
@@ -106,10 +116,12 @@ export const useUsageStore = defineStore('usage', () => {
 		setLoading,
 		getLicenseInfo,
 		setData,
+		setPlansEnabled,
 		activateLicense,
 		refreshLicenseManagementToken,
 		requestEnterpriseLicenseTrial,
 		registerCommunityEdition,
+		plansEnabled,
 		planName,
 		planId,
 		activeWorkflowTriggersLimit,

--- a/packages/frontend/editor-ui/src/views/SettingsUsageAndPlan.vue
+++ b/packages/frontend/editor-ui/src/views/SettingsUsageAndPlan.vue
@@ -156,6 +156,10 @@ const openCommunityRegisterModal = () => {
 		},
 	});
 };
+
+const togglePlans = () => {
+	usageStore.setPlansEnabled(!usageStore.plansEnabled);
+};
 </script>
 
 <template>
@@ -164,6 +168,10 @@ const openCommunityRegisterModal = () => {
 			locale.baseText('settings.usageAndPlan.title')
 		}}</n8n-heading>
 		<div v-if="!usageStore.isLoading">
+			<N8nButton
+				:label="usageStore.plansEnabled ? 'Disable plan restrictions' : 'Enable plan restrictions'"
+				@click="togglePlans"
+			/>
 			<n8n-heading tag="h3" :class="$style.title" size="large">
 				<I18nT keypath="settings.usageAndPlan.description" tag="span" scope="global">
 					<template #name>{{ badgedPlanName.name ?? usageStore.planName }}</template>


### PR DESCRIPTION
## Summary
- add usage store flag to control plan restrictions
- add settings toggle to enable or disable plan enforcement

## Testing
- `pnpm --filter=n8n-editor-ui lint`
- `pnpm --filter=n8n-editor-ui test` *(fails: terminated early due to environment constraints)*

------
https://chatgpt.com/codex/tasks/task_e_68c5d47e1d7c8323bfe670363613dafa