### PR TITLE
feat: add workflow suggestions

### DIFF
--- a/packages/cli/src/controllers/ai.controller.ts
+++ b/packages/cli/src/controllers/ai.controller.ts
@@ -221,4 +221,15 @@ export class AiController {
 			throw new InternalServerError(e.message, e);
 		}
 	}
+
+	@Post('/suggestions', { rateLimit: { limit: 100 } })
+	async suggestions(req: AuthenticatedRequest, _: Response, @Body payload: { prompt: string }) {
+		try {
+			const actions = await this.aiService.getSuggestions(payload.prompt);
+			return { actions };
+		} catch (e) {
+			assert(e instanceof Error);
+			throw new InternalServerError(e.message, e);
+		}
+	}
 }

--- a/packages/cli/src/services/ai.service.ts
+++ b/packages/cli/src/services/ai.service.ts
@@ -7,6 +7,7 @@ import { GlobalConfig } from '@n8n/config';
 import { Service } from '@n8n/di';
 import { AiAssistantClient } from '@n8n_io/ai-assistant-sdk';
 import { assert, type IUser } from 'n8n-workflow';
+import { requestSuggestions } from 'n8n-core';
 
 import { N8N_VERSION } from '../constants';
 import { License } from '../license';
@@ -75,5 +76,9 @@ export class AiService {
 		assert(this.client, 'Assistant client not setup');
 
 		return await this.client.generateAiCreditsCredentials(user);
+	}
+
+	async getSuggestions(prompt: string) {
+		return await requestSuggestions(prompt);
 	}
 }

--- a/packages/core/src/ai-suggestions.ts
+++ b/packages/core/src/ai-suggestions.ts
@@ -1,0 +1,14 @@
+import axios from 'axios'
+
+export type SuggestionAction =
+  | { type: 'addNode'; node: Record<string, unknown> }
+  | { type: 'updateParameter'; node: string; parameter: string; value: unknown }
+
+export async function requestSuggestions(prompt: string): Promise<SuggestionAction[]> {
+  const url = process.env.LLM_API_URL
+  if (!url) throw new Error('LLM_API_URL missing')
+  const headers: Record<string, string> = {}
+  if (process.env.LLM_API_KEY) headers.Authorization = `Bearer ${process.env.LLM_API_KEY}`
+  const { data } = await axios.post(url, { prompt }, { headers })
+  return Array.isArray(data.actions) ? data.actions : []
+}

--- a/packages/core/src/index.ts
+++ b/packages/core/src/index.ts
@@ -12,6 +12,7 @@ export * from './instance-settings';
 export * from './nodes-loader';
 export * from './utils';
 export { WorkflowHasIssuesError } from './errors/workflow-has-issues.error';
+export * from './ai-suggestions';
 
 export * from './interfaces';
 export * from './node-execute-functions';

--- a/packages/frontend/editor-ui/src/components/Node/NodeCreation.vue
+++ b/packages/frontend/editor-ui/src/components/Node/NodeCreation.vue
@@ -21,6 +21,7 @@ import AssistantIcon from '@n8n/design-system/components/AskAssistantIcon/Assist
 import { useI18n } from '@n8n/i18n';
 import { useTelemetry } from '@/composables/useTelemetry';
 import { useAssistantStore } from '@/stores/assistant.store';
+import { useAiSuggestions } from '@/composables/useAiSuggestions';
 
 type Props = {
 	nodeViewScale: number;
@@ -46,6 +47,7 @@ const focusPanelStore = useFocusPanelStore();
 const i18n = useI18n();
 const telemetry = useTelemetry();
 const assistantStore = useAssistantStore();
+const { requestSuggestions } = useAiSuggestions();
 
 const { getAddedNodesAndConnections } = useActions();
 
@@ -100,6 +102,10 @@ function onAskAssistantButtonClick() {
 
 	assistantStore.toggleChatOpen();
 }
+
+function onSuggestClick() {
+	void requestSuggestions();
+}
 </script>
 
 <template>
@@ -115,6 +121,15 @@ function onAskAssistantButtonClick() {
 				type="tertiary"
 				data-test-id="node-creator-plus-button"
 				@click="openNodeCreator"
+			/>
+		</KeyboardShortcutTooltip>
+		<KeyboardShortcutTooltip label="AI Suggestions" placement="left">
+			<n8n-icon-button
+				size="large"
+				type="tertiary"
+				icon="sparkles"
+				data-test-id="ai-suggestions-button"
+				@click="onSuggestClick"
 			/>
 		</KeyboardShortcutTooltip>
 		<KeyboardShortcutTooltip

--- a/packages/frontend/editor-ui/src/composables/useAiSuggestions.ts
+++ b/packages/frontend/editor-ui/src/composables/useAiSuggestions.ts
@@ -1,0 +1,21 @@
+import axios from 'axios'
+import { useWorkflowsStore } from '@/stores/workflows.store'
+import { useCanvasOperations } from './useCanvasOperations'
+
+export function useAiSuggestions() {
+  const workflowsStore = useWorkflowsStore()
+  const canvasOperations = useCanvasOperations()
+
+  async function requestSuggestions() {
+    const { data } = await axios.post('/rest/ai/suggestions', { workflow: workflowsStore.workflow.value })
+    for (const action of data.actions ?? []) {
+      if (action.type === 'addNode' && action.node) {
+        await canvasOperations.addNodes([action.node], {})
+      } else if (action.type === 'updateParameter' && action.node && action.parameter) {
+        workflowsStore.setNodeValue({ name: action.node, key: `parameters.${action.parameter}`, value: action.value })
+      }
+    }
+  }
+
+  return { requestSuggestions }
+}


### PR DESCRIPTION
## Summary
- add backend service and endpoint for workflow suggestions
- expose suggestions button in editor UI
- translate model responses into node additions or parameter updates

## Testing
- `pnpm --filter n8n-core test` *(fails: Cannot find module 'n8n-workflow')*
- `pnpm --filter n8n test` *(fails: Cannot find module 'n8n-workflow')*
- `pnpm --filter n8n-editor-ui test` *(fails: Cannot find module 'n8n-workflow')*

------
https://chatgpt.com/codex/tasks/task_e_68c5f0b277a8832385efce794dd050f5