### PR TITLE
feat: add workflow websocket broadcast

### DIFF
--- a/packages/core/package.json
+++ b/packages/core/package.json
@@ -75,6 +75,7 @@
     "uuid": "catalog:",
     "winston": "3.14.2",
     "xml2js": "catalog:",
-    "zod": "catalog:"
+    "zod": "catalog:",
+    "ws": "catalog:"
   }
 }

--- a/packages/core/src/index.ts
+++ b/packages/core/src/index.ts
@@ -12,6 +12,7 @@ export * from './instance-settings';
 export * from './nodes-loader';
 export * from './utils';
 export { WorkflowHasIssuesError } from './errors/workflow-has-issues.error';
+export * from './workflow-ws.service';
 
 export * from './interfaces';
 export * from './node-execute-functions';

--- a/packages/core/src/workflow-ws.service.ts
+++ b/packages/core/src/workflow-ws.service.ts
@@ -1,0 +1,47 @@
+import type { Server as HttpServer } from 'http';
+import WebSocket, { WebSocketServer } from 'ws';
+
+type Client = WebSocket & { workflowId?: string };
+
+export class WorkflowWsService {
+	private wss?: WebSocketServer;
+	private channels = new Map<string, Set<Client>>();
+
+	start(server: HttpServer) {
+		this.wss = new WebSocketServer({ server });
+		this.wss.on('connection', (ws: Client) => {
+			ws.on('message', (msg) => {
+				let data;
+				try {
+					data = JSON.parse(msg.toString());
+				} catch {
+					return;
+				}
+				if (data.type === 'join') {
+					ws.workflowId = data.workflowId;
+					const set = this.channels.get(data.workflowId) ?? new Set();
+					set.add(ws);
+					this.channels.set(data.workflowId, set);
+					return;
+				}
+				if (data.workflowId) {
+					const set = this.channels.get(data.workflowId);
+					if (!set) return;
+					for (const client of set) {
+						if (client !== ws && client.readyState === WebSocket.OPEN) {
+							client.send(msg.toString());
+						}
+					}
+				}
+			});
+			ws.on('close', () => {
+				const id = ws.workflowId;
+				if (!id) return;
+				const set = this.channels.get(id);
+				if (!set) return;
+				set.delete(ws);
+				if (!set.size) this.channels.delete(id);
+			});
+		});
+	}
+}

--- a/packages/frontend/@n8n/stores/src/constants.ts
+++ b/packages/frontend/@n8n/stores/src/constants.ts
@@ -22,6 +22,7 @@ export const STORES = {
 	RBAC: 'rbac',
 	PUSH: 'push',
 	COLLABORATION: 'collaboration',
+	WORKFLOW_COLLAB: 'workflowCollab',
 	ASSISTANT: 'assistant',
 	BUILDER: 'builder',
 	BECOME_TEMPLATE_CREATOR: 'becomeTemplateCreator',

--- a/packages/frontend/editor-ui/src/stores/workflowCollab.store.ts
+++ b/packages/frontend/editor-ui/src/stores/workflowCollab.store.ts
@@ -1,0 +1,72 @@
+import { defineStore } from 'pinia';
+import { ref } from 'vue';
+import { useRootStore } from '@n8n/stores/useRootStore';
+import { useWorkflowsStore } from './workflows.store';
+import { useUsersStore } from './users.store';
+import { useWebSocketClient } from '@/push-connection/useWebSocketClient';
+
+export const useWorkflowCollabStore = defineStore('workflowCollab', () => {
+	const rootStore = useRootStore();
+	const workflowsStore = useWorkflowsStore();
+	const usersStore = useUsersStore();
+	const cursors = ref<Record<string, unknown>>({});
+	let client: ReturnType<typeof useWebSocketClient> | null = null;
+	function wsUrl() {
+		const rest = rootStore.restUrl;
+		const { protocol, host } = window.location;
+		const base = rest.startsWith('http')
+			? rest.replace(/^http/, 'ws')
+			: `${protocol === 'https:' ? 'wss' : 'ws'}://${host + rest}`;
+		return `${base}/workflow`;
+	}
+	function onMessage(data: unknown) {
+		let msg;
+		try {
+			msg = JSON.parse(data as string);
+		} catch {
+			return;
+		}
+		if (msg.type === 'update' && msg.workflowId === workflowsStore.workflowId) {
+			workflowsStore.setWorkflow(msg.workflow);
+		}
+		if (msg.type === 'cursor' && msg.workflowId === workflowsStore.workflowId) {
+			cursors.value[msg.userId] = msg.cursor;
+		}
+	}
+	function connect() {
+		client = useWebSocketClient({ url: wsUrl(), onMessage });
+		client.connect();
+		client.sendMessage(
+			JSON.stringify({
+				type: 'join',
+				workflowId: workflowsStore.workflowId,
+				userId: usersStore.currentUserId,
+			}),
+		);
+	}
+	function disconnect() {
+		client?.disconnect();
+		client = null;
+	}
+	function sendUpdate(workflow: object) {
+		client?.sendMessage(
+			JSON.stringify({
+				type: 'update',
+				workflowId: workflowsStore.workflowId,
+				userId: usersStore.currentUserId,
+				workflow,
+			}),
+		);
+	}
+	function sendCursor(cursor: unknown) {
+		client?.sendMessage(
+			JSON.stringify({
+				type: 'cursor',
+				workflowId: workflowsStore.workflowId,
+				userId: usersStore.currentUserId,
+				cursor,
+			}),
+		);
+	}
+	return { cursors, connect, disconnect, sendUpdate, sendCursor };
+});


### PR DESCRIPTION
## Summary
- add workflow websocket service to core for broadcasting updates
- expose workflow collaboration store in editor UI
- register workflow collaboration store constant

## Testing
- `pnpm --filter @n8n/stores test` *(fails: Cannot find module '@n8n/vitest-config')*
- `pnpm --filter n8n-core test` *(fails: Cannot find module 'n8n-workflow')*
- `pnpm --filter n8n-editor-ui test` *(fails: Cannot find module '@n8n/backend-common')*

------
https://chatgpt.com/codex/tasks/task_e_68c5f0af0c108323892d12db5a43d117