### PR TITLE
feat: add portable n8n setup script

### DIFF
--- a/scripts/portable-n8n.sh
+++ b/scripts/portable-n8n.sh
@@ -1,0 +1,21 @@
+#!/usr/bin/env bash
+set -e
+cd "$(dirname "$0")/.."
+NODE_VERSION=22.16.0
+if [ ! -d node ]; then
+  curl -fsSL https://nodejs.org/dist/v$NODE_VERSION/node-v$NODE_VERSION-linux-x64.tar.xz | tar -xJf -
+  mv node-v$NODE_VERSION-linux-x64 node
+fi
+export PATH="$PWD/node/bin:$PATH"
+corepack enable
+corepack prepare pnpm@10.12.1 --activate
+if [ ! -d node_modules ]; then
+  pnpm install --prod
+  pnpm build
+fi
+if [ ! -f .env ]; then
+  echo "N8N_ENCRYPTION_KEY=$(openssl rand -hex 32)" > .env
+  echo "N8N_HOST=0.0.0.0" >> .env
+  echo "N8N_PORT=5678" >> .env
+fi
+packages/cli/bin/n8n start


### PR DESCRIPTION
## Summary
- add script to install dependencies and run n8n without root

## Testing
- `pnpm lint` *(fails: sh: 1: turbo: not found)*
- `yes | npx turbo lint` *(fails: command exited with error)*

------
https://chatgpt.com/codex/tasks/task_e_68c5fd67a99c8323bff400e9f813fbd0