### PR TITLE
feat: prioritize operations and enhance node search

### DIFF
--- a/packages/@n8n/ai-workflow-builder.ee/src/tools/engines/node-search-engine.ts
+++ b/packages/@n8n/ai-workflow-builder.ee/src/tools/engines/node-search-engine.ts
@@ -1,89 +1,116 @@
 import type { INodeTypeDescription, NodeConnectionType } from 'n8n-workflow';
 import { NodeConnectionTypes } from 'n8n-workflow';
-
 import type { NodeSearchResult } from '../../types/nodes';
+import { DEFAULT_SYNONYMS } from './synonyms';
 
-/**
- * Scoring weights for different match types
- */
 export const SCORE_WEIGHTS = {
-	NAME_CONTAINS: 10,
-	DISPLAY_NAME_CONTAINS: 8,
-	DESCRIPTION_CONTAINS: 5,
-	ALIAS_CONTAINS: 8,
-	NAME_EXACT: 20,
-	DISPLAY_NAME_EXACT: 15,
-	CONNECTION_EXACT: 100,
-	CONNECTION_IN_EXPRESSION: 50,
+        NAME_CONTAINS: 10,
+        DISPLAY_NAME_CONTAINS: 8,
+        DESCRIPTION_CONTAINS: 5,
+        ALIAS_CONTAINS: 8,
+        NAME_EXACT: 20,
+        DISPLAY_NAME_EXACT: 15,
+        CONNECTION_EXACT: 100,
+        CONNECTION_IN_EXPRESSION: 50,
 } as const;
 
-/**
- * Pure business logic for searching nodes
- * Separated from tool infrastructure for better testability
- */
+type ProcessedNode = {
+        node: INodeTypeDescription;
+        normalizedName: string;
+        normalizedDisplayName: string;
+        normalizedDescription: string;
+        normalizedAlias: string[];
+};
+
 export class NodeSearchEngine {
-	constructor(private readonly nodeTypes: INodeTypeDescription[]) {}
+        private processed: ProcessedNode[];
+        private nameSearchCache = new Map<string, NodeSearchResult[]>();
+        private connectionSearchCache = new Map<string, NodeSearchResult[]>();
+        private synonymMap = new Map<string, string>();
+        constructor(
+                nodeTypes: INodeTypeDescription[],
+                synonyms: Record<string, string[]> = DEFAULT_SYNONYMS,
+        ) {
+                this.processed = nodeTypes.map((nt) => ({
+                        node: nt,
+                        normalizedName: NodeSearchEngine.normalize(nt.name),
+                        normalizedDisplayName: NodeSearchEngine.normalize(nt.displayName),
+                        normalizedDescription: nt.description
+                                ? NodeSearchEngine.normalize(nt.description)
+                                : '',
+                        normalizedAlias:
+                                nt.codex?.alias?.map((a) => NodeSearchEngine.normalize(a)) ?? [],
+                }));
+                for (const [canonical, syns] of Object.entries(synonyms)) {
+                        const normCanon = NodeSearchEngine.normalize(canonical);
+                        for (const s of syns) this.synonymMap.set(NodeSearchEngine.normalize(s), normCanon);
+                }
+        }
 
-	/**
-	 * Search nodes by name, display name, or description
-	 * @param query - The search query string
-	 * @param limit - Maximum number of results to return
-	 * @returns Array of matching nodes sorted by relevance
-	 */
-	searchByName(query: string, limit: number = 20): NodeSearchResult[] {
-		const normalizedQuery = query.toLowerCase();
-		const results: NodeSearchResult[] = [];
+        private static normalize(text: string): string {
+                return text.toLowerCase().normalize('NFD').replace(/[\u0300-\u036f]/g, '');
+        }
 
-		for (const nodeType of this.nodeTypes) {
-			try {
-				const score = this.calculateNameScore(nodeType, normalizedQuery);
-				if (score > 0) {
-					results.push(this.createSearchResult(nodeType, score));
-				}
-			} catch (error) {
-				// Ignore errors for now
-			}
-		}
+        /**
+         * Search nodes by name, display name, or description
+         * @param query - The search query string
+         * @param limit - Maximum number of results to return
+         * @returns Array of matching nodes sorted by relevance
+         */
+        searchByName(query: string, limit: number = 20): NodeSearchResult[] {
+                const normalizedQuery = NodeSearchEngine.normalize(query);
+                const canonicalQuery = this.synonymMap.get(normalizedQuery) ?? normalizedQuery;
+                const key = `${canonicalQuery}|${limit}`;
+                const cached = this.nameSearchCache.get(key);
+                if (cached) return cached;
+                const results: NodeSearchResult[] = [];
+                for (const p of this.processed) {
+                        try {
+                                const score = this.calculateNameScore(p, canonicalQuery);
+                                if (score > 0) results.push(this.createSearchResult(p.node, score));
+                        } catch (error) {}
+                }
+                const sorted = this.sortAndLimit(results, limit);
+                this.nameSearchCache.set(key, sorted);
+                return sorted;
+        }
 
-		return this.sortAndLimit(results, limit);
-	}
-
-	/**
-	 * Search for sub-nodes that output a specific connection type
-	 * @param connectionType - The connection type to search for
-	 * @param limit - Maximum number of results
-	 * @param nameFilter - Optional name filter
-	 * @returns Array of matching sub-nodes
-	 */
-	searchByConnectionType(
-		connectionType: NodeConnectionType,
-		limit: number = 20,
-		nameFilter?: string,
-	): NodeSearchResult[] {
-		const results: NodeSearchResult[] = [];
-		const normalizedFilter = nameFilter?.toLowerCase();
-
-		for (const nodeType of this.nodeTypes) {
-			try {
-				const connectionScore = this.getConnectionScore(nodeType, connectionType);
-				if (connectionScore > 0) {
-					// Apply name filter if provided
-					const nameScore = normalizedFilter
-						? this.calculateNameScore(nodeType, normalizedFilter)
-						: 0;
-
-					if (!normalizedFilter || nameScore > 0) {
-						const totalScore = connectionScore + nameScore;
-						results.push(this.createSearchResult(nodeType, totalScore));
-					}
-				}
-			} catch (error) {
-				// Ignore errors for now
-			}
-		}
-
-		return this.sortAndLimit(results, limit);
-	}
+        /**
+         * Search for sub-nodes that output a specific connection type
+         * @param connectionType - The connection type to search for
+         * @param limit - Maximum number of results
+         * @param nameFilter - Optional name filter
+         * @returns Array of matching sub-nodes
+         */
+        searchByConnectionType(
+                connectionType: NodeConnectionType,
+                limit: number = 20,
+                nameFilter?: string,
+        ): NodeSearchResult[] {
+                const normalizedFilter = nameFilter ? NodeSearchEngine.normalize(nameFilter) : undefined;
+                const canonicalFilter = normalizedFilter
+                        ? this.synonymMap.get(normalizedFilter) ?? normalizedFilter
+                        : undefined;
+                const key = `${connectionType}|${canonicalFilter ?? ''}|${limit}`;
+                const cached = this.connectionSearchCache.get(key);
+                if (cached) return cached;
+                const results: NodeSearchResult[] = [];
+                for (const p of this.processed) {
+                        try {
+                                const connectionScore = this.getConnectionScore(p.node, connectionType);
+                                if (connectionScore > 0) {
+                                        const nameScore = canonicalFilter ? this.calculateNameScore(p, canonicalFilter) : 0;
+                                        if (!canonicalFilter || nameScore > 0) {
+                                                const totalScore = connectionScore + nameScore;
+                                                results.push(this.createSearchResult(p.node, totalScore));
+                                        }
+                                }
+                        } catch (error) {}
+                }
+                const sorted = this.sortAndLimit(results, limit);
+                this.connectionSearchCache.set(key, sorted);
+                return sorted;
+        }
 
 	/**
 	 * Format search results for tool output
@@ -100,45 +127,16 @@ export class NodeSearchEngine {
 		</node>`;
 	}
 
-	/**
-	 * Calculate score based on name matches
-	 * @param nodeType - Node type to score
-	 * @param normalizedQuery - Lowercase search query
-	 * @returns Numeric score
-	 */
-	private calculateNameScore(nodeType: INodeTypeDescription, normalizedQuery: string): number {
-		let score = 0;
-
-		// Check name match
-		if (nodeType.name.toLowerCase().includes(normalizedQuery)) {
-			score += SCORE_WEIGHTS.NAME_CONTAINS;
-		}
-
-		// Check display name match
-		if (nodeType.displayName.toLowerCase().includes(normalizedQuery)) {
-			score += SCORE_WEIGHTS.DISPLAY_NAME_CONTAINS;
-		}
-
-		// Check description match
-		if (nodeType.description?.toLowerCase().includes(normalizedQuery)) {
-			score += SCORE_WEIGHTS.DESCRIPTION_CONTAINS;
-		}
-
-		// Check alias match
-		if (nodeType.codex?.alias?.some((alias) => alias.toLowerCase().includes(normalizedQuery))) {
-			score += SCORE_WEIGHTS.ALIAS_CONTAINS;
-		}
-
-		// Check exact matches (boost score)
-		if (nodeType.name.toLowerCase() === normalizedQuery) {
-			score += SCORE_WEIGHTS.NAME_EXACT;
-		}
-		if (nodeType.displayName.toLowerCase() === normalizedQuery) {
-			score += SCORE_WEIGHTS.DISPLAY_NAME_EXACT;
-		}
-
-		return score;
-	}
+        private calculateNameScore(node: ProcessedNode, normalizedQuery: string): number {
+                let score = 0;
+                if (node.normalizedName.includes(normalizedQuery)) score += SCORE_WEIGHTS.NAME_CONTAINS;
+                if (node.normalizedDisplayName.includes(normalizedQuery)) score += SCORE_WEIGHTS.DISPLAY_NAME_CONTAINS;
+                if (node.normalizedDescription.includes(normalizedQuery)) score += SCORE_WEIGHTS.DESCRIPTION_CONTAINS;
+                if (node.normalizedAlias.some((alias) => alias.includes(normalizedQuery))) score += SCORE_WEIGHTS.ALIAS_CONTAINS;
+                if (node.normalizedName === normalizedQuery) score += SCORE_WEIGHTS.NAME_EXACT;
+                if (node.normalizedDisplayName === normalizedQuery) score += SCORE_WEIGHTS.DISPLAY_NAME_EXACT;
+                return score;
+        }
 
 	/**
 	 * Check if a node has a specific connection type in outputs

--- a/packages/@n8n/ai-workflow-builder.ee/src/tools/engines/synonyms.ts
+++ b/packages/@n8n/ai-workflow-builder.ee/src/tools/engines/synonyms.ts
@@ -1,0 +1,4 @@
+export const DEFAULT_SYNONYMS: Record<string, string[]> = {
+        send: ['enviar', 'mandar'],
+        request: ['pedido', 'solicitação'],
+};

--- a/packages/@n8n/ai-workflow-builder.ee/src/tools/engines/test/node-search-engine.test.ts
+++ b/packages/@n8n/ai-workflow-builder.ee/src/tools/engines/test/node-search-engine.test.ts
@@ -58,16 +58,22 @@ describe('NodeSearchEngine', () => {
 				inputs: [],
 				outputs: ['ai_memory'],
 			}),
-			createNodeType({
-				name: 'n8n-nodes-base.httpBin',
-				displayName: 'HTTP Bin',
-				description: 'Test HTTP requests with httpbin.org',
-				group: ['input'],
-				codex: {
-					alias: ['httpbin', 'request bin'],
-				},
-			}),
-		];
+                        createNodeType({
+                                name: 'n8n-nodes-base.httpBin',
+                                displayName: 'HTTP Bin',
+                                description: 'Test HTTP requests with httpbin.org',
+                                group: ['input'],
+                                codex: {
+                                        alias: ['httpbin', 'request bin'],
+                                },
+                        }),
+                        createNodeType({
+                                name: 'n8n-nodes-base.emailSend',
+                                displayName: 'Send Email',
+                                description: 'Send an email message',
+                                group: ['output'],
+                        }),
+                ];
 
 		searchEngine = new NodeSearchEngine(nodeTypes);
 	});
@@ -115,17 +121,22 @@ describe('NodeSearchEngine', () => {
 			expect(results[0].score).toBeGreaterThanOrEqual(SCORE_WEIGHTS.ALIAS_CONTAINS);
 		});
 
-		it('should handle case-insensitive search', () => {
-			const resultsLower = searchEngine.searchByName('webhook');
-			const resultsUpper = searchEngine.searchByName('WEBHOOK');
-			const resultsMixed = searchEngine.searchByName('WebHook');
+                it('should handle case-insensitive search', () => {
+                        const resultsLower = searchEngine.searchByName('webhook');
+                        const resultsUpper = searchEngine.searchByName('WEBHOOK');
+                        const resultsMixed = searchEngine.searchByName('WebHook');
 
 			expect(resultsLower).toHaveLength(1);
 			expect(resultsUpper).toHaveLength(1);
 			expect(resultsMixed).toHaveLength(1);
 			expect(resultsLower[0].name).toBe(resultsUpper[0].name);
-			expect(resultsLower[0].name).toBe(resultsMixed[0].name);
-		});
+                        expect(resultsLower[0].name).toBe(resultsMixed[0].name);
+                });
+
+                it('should match synonyms', () => {
+                        const results = searchEngine.searchByName('enviar');
+                        expect(results.some((r) => r.name === 'n8n-nodes-base.emailSend')).toBe(true);
+                });
 
 		it('should return empty array for no matches', () => {
 			const results = searchEngine.searchByName('nonexistent');

--- a/packages/@n8n/ai-workflow-builder.ee/src/tools/test/node-search.tool.test.ts
+++ b/packages/@n8n/ai-workflow-builder.ee/src/tools/test/node-search.tool.test.ts
@@ -38,11 +38,12 @@ describe('NodeSearchTool', () => {
 				description: 'Starts workflow on webhook call',
 			}),
 			nodeTypes.setNode,
-			nodeTypes.ifNode,
-			nodeTypes.mergeNode,
-			// AI nodes
-			nodeTypes.openAiModel,
-			nodeTypes.agent,
+                        nodeTypes.ifNode,
+                        nodeTypes.mergeNode,
+                        nodeTypes.sendEmail,
+                        // AI nodes
+                        nodeTypes.openAiModel,
+                        nodeTypes.agent,
 			createNodeType({
 				name: '@n8n/n8n-nodes-langchain.toolCalculator',
 				displayName: 'Calculator Tool',
@@ -314,8 +315,8 @@ describe('NodeSearchTool', () => {
 			expect(message).toContain('<node_name>@n8n/n8n-nodes-langchain.vectorStore</node_name>');
 		});
 
-		it('should handle case-insensitive search', async () => {
-			const mockConfig = createToolConfig('search_nodes', 'test-call-12');
+                it('should handle case-insensitive search', async () => {
+                        const mockConfig = createToolConfig('search_nodes', 'test-call-12');
 
 			const result = await nodeSearchTool.invoke(
 				{
@@ -329,10 +330,24 @@ describe('NodeSearchTool', () => {
 
 			expectToolSuccess(content, 'Found');
 			expect(message).toContain('<node_name>n8n-nodes-base.code</node_name>');
-			expect(message).toContain('<node_name>@n8n/n8n-nodes-langchain.toolCode</node_name>');
-		});
+                        expect(message).toContain('<node_name>@n8n/n8n-nodes-langchain.toolCode</node_name>');
+                });
 
-		it('should respect result limit', async () => {
+                it('should search nodes by synonym', async () => {
+                        const mockConfig = createToolConfigWithWriter('search_nodes', 'test-call-17');
+                        const result = await nodeSearchTool.invoke(
+                                {
+                                        queries: [buildNodeSearchQuery('name', 'enviar')],
+                                },
+                                mockConfig,
+                        );
+                        const content = parseToolResult<ParsedToolContent>(result);
+                        const message = content.update.messages[0]?.kwargs.content;
+                        expectToolSuccess(content, 'Found');
+                        expect(message).toContain('<node_name>n8n-nodes-base.emailSend</node_name>');
+                });
+
+                it('should respect result limit', async () => {
 			// Add many nodes that would match
 			const manyHttpNodes = Array.from({ length: 20 }, (_, i) =>
 				createNodeType({

--- a/packages/@n8n/ai-workflow-builder.ee/src/utils/operations-processor.ts
+++ b/packages/@n8n/ai-workflow-builder.ee/src/utils/operations-processor.ts
@@ -3,6 +3,20 @@ import type { INode, IConnections } from 'n8n-workflow';
 import type { SimpleWorkflow, WorkflowOperation } from '../types/workflow';
 import type { WorkflowState } from '../workflow-state';
 
+const OPERATION_PRIORITY: Record<WorkflowOperation['type'], number> = {
+        clear: 0,
+        removeNode: 1,
+        setConnections: 2,
+        mergeConnections: 3,
+        addNodes: 4,
+        updateNode: 5,
+        setName: 6,
+};
+
+function sortOperations(operations: WorkflowOperation[]): WorkflowOperation[] {
+        return operations.slice().sort((a, b) => OPERATION_PRIORITY[a.type] - OPERATION_PRIORITY[b.type]);
+}
+
 /**
  * Apply a list of operations to a workflow
  */
@@ -18,12 +32,11 @@ export function applyOperations(
 		name: workflow.name || '',
 	};
 
-	// Apply each operation in sequence
-	for (const operation of operations) {
-		switch (operation.type) {
-			case 'clear':
-				result = { nodes: [], connections: {}, name: '' };
-				break;
+        for (const operation of sortOperations(operations)) {
+                switch (operation.type) {
+                        case 'clear':
+                                result = { nodes: [], connections: {}, name: '' };
+                                break;
 
 			case 'removeNode': {
 				const nodesToRemove = new Set(operation.nodeIds);

--- a/packages/@n8n/ai-workflow-builder.ee/test/test-utils.ts
+++ b/packages/@n8n/ai-workflow-builder.ee/test/test-utils.ts
@@ -173,32 +173,38 @@ export const nodeTypes = {
 			},
 		],
 	}),
-	mergeNode: createNodeType({
-		displayName: 'Merge',
-		name: 'n8n-nodes-base.merge',
-		group: ['transform'],
-		inputs: ['main', 'main'],
-		outputs: ['main'],
-		inputNames: ['Input 1', 'Input 2'],
-		properties: [
-			{
-				displayName: 'Mode',
-				name: 'mode',
-				type: 'options',
-				options: [
-					{ name: 'Append', value: 'append' },
-					{ name: 'Merge By Index', value: 'mergeByIndex' },
-					{ name: 'Merge By Key', value: 'mergeByKey' },
-				],
-				default: 'append',
-			},
-		],
-	}),
-	vectorStoreNode: createNodeType({
-		displayName: 'Vector Store',
-		name: '@n8n/n8n-nodes-langchain.vectorStore',
-		subtitle: '={{$parameter["mode"] === "retrieve" ? "Retrieve" : "Insert"}}',
-		group: ['transform'],
+        mergeNode: createNodeType({
+                displayName: 'Merge',
+                name: 'n8n-nodes-base.merge',
+                group: ['transform'],
+                inputs: ['main', 'main'],
+                outputs: ['main'],
+                inputNames: ['Input 1', 'Input 2'],
+                properties: [
+                        {
+                                displayName: 'Mode',
+                                name: 'mode',
+                                type: 'options',
+                                options: [
+                                        { name: 'Append', value: 'append' },
+                                        { name: 'Merge By Index', value: 'mergeByIndex' },
+                                        { name: 'Merge By Key', value: 'mergeByKey' },
+                                ],
+                                default: 'append',
+                        },
+                ],
+        }),
+        sendEmail: createNodeType({
+                displayName: 'Send Email',
+                name: 'n8n-nodes-base.emailSend',
+                description: 'Send email',
+                group: ['output'],
+        }),
+        vectorStoreNode: createNodeType({
+                displayName: 'Vector Store',
+                name: '@n8n/n8n-nodes-langchain.vectorStore',
+                subtitle: '={{$parameter["mode"] === "retrieve" ? "Retrieve" : "Insert"}}',
+                group: ['transform'],
 		inputs: `={{ ((parameter) => {
 			function getInputs(parameters) {
 				const mode = parameters?.mode;


### PR DESCRIPTION
## Summary
- sort workflow operations by importance before execution
- cache, normalize, and apply synonym mapping for node search to handle natural language variants

## Testing
- `pnpm --filter @n8n/ai-workflow-builder lint` *(fails: Cannot find package 'eslint')*
- `pnpm --filter @n8n/ai-workflow-builder test` *(fails: jest: not found)*

------
https://chatgpt.com/codex/tasks/task_e_68c5fe0b5a508323a780c133a48cdb69