### PR TITLE
feat: central model provider configuration

### DIFF
--- a/packages/@n8n/ai-workflow-builder.ee/src/index.ts
+++ b/packages/@n8n/ai-workflow-builder.ee/src/index.ts
@@ -1,3 +1,4 @@
 export * from './ai-workflow-builder-agent.service';
 export * from './types';
 export * from './workflow-state';
+export * from './model-provider';

--- a/packages/@n8n/ai-workflow-builder.ee/src/llm-config.ts
+++ b/packages/@n8n/ai-workflow-builder.ee/src/llm-config.ts
@@ -1,5 +1,5 @@
 // Different LLMConfig type for this file - specific to LLM providers
-interface LLMProviderConfig {
+export interface LLMProviderConfig {
 	apiKey: string;
 	baseUrl?: string;
 	headers?: Record<string, string>;

--- a/packages/@n8n/ai-workflow-builder.ee/src/model-provider.ts
+++ b/packages/@n8n/ai-workflow-builder.ee/src/model-provider.ts
@@ -1,0 +1,36 @@
+import { o4mini, gpt41mini, gpt41, anthropicClaudeSonnet4, LLMProviderConfig } from './llm-config';
+
+export type ModelProvider = 'openai-o4-mini' | 'openai-gpt-4.1-mini' | 'openai-gpt-4.1' | 'anthropic-claude-sonnet-4';
+
+interface ProviderConfig extends LLMProviderConfig {
+        provider: ModelProvider;
+}
+
+let currentConfig: ProviderConfig | null = null;
+
+export const setModelProvider = (config: ProviderConfig) => {
+        currentConfig = config;
+};
+
+export const getModelProvider = () => currentConfig;
+
+export const createModel = async () => {
+        if (!currentConfig) throw new Error('Model provider is not configured');
+        const { provider, ...rest } = currentConfig;
+        switch (provider) {
+                case 'openai-o4-mini':
+                        return o4mini(rest);
+                case 'openai-gpt-4.1-mini':
+                        return gpt41mini(rest);
+                case 'openai-gpt-4.1':
+                        return gpt41(rest);
+                case 'anthropic-claude-sonnet-4':
+                        return anthropicClaudeSonnet4(rest);
+        }
+};
+
+const envProvider = process.env.N8N_AI_PROVIDER as ModelProvider | undefined;
+const envKey = process.env.N8N_AI_API_KEY;
+if (envProvider && envKey) {
+        setModelProvider({ provider: envProvider, apiKey: envKey, baseUrl: process.env.N8N_AI_BASE_URL });
+}

--- a/packages/@n8n/ai-workflow-builder.ee/test/model-provider.test.ts
+++ b/packages/@n8n/ai-workflow-builder.ee/test/model-provider.test.ts
@@ -1,0 +1,8 @@
+import { setModelProvider, getModelProvider } from '../src/model-provider';
+
+describe('model provider', () => {
+        it('stores provider config', () => {
+                setModelProvider({ provider: 'openai-o4-mini', apiKey: 'key' });
+                expect(getModelProvider()).toEqual({ provider: 'openai-o4-mini', apiKey: 'key' });
+        });
+});


### PR DESCRIPTION
## Summary
- expose LLMProviderConfig for reuse
- add central model provider registry with env-based initialization
- verify provider storage with basic test

## Testing
- `pnpm --filter @n8n/ai-workflow-builder lint` (fails: Cannot find package 'eslint')
- `pnpm --filter @n8n/ai-workflow-builder test` (fails: jest: not found)


------
https://chatgpt.com/codex/tasks/task_e_68c601e3644083238c3c3451fd8f38ad